### PR TITLE
ensuring that all fields are included

### DIFF
--- a/src/Enterspeed.Source.SitecoreCms.V9/Services/EnterspeedFieldConverter.cs
+++ b/src/Enterspeed.Source.SitecoreCms.V9/Services/EnterspeedFieldConverter.cs
@@ -68,10 +68,6 @@ namespace Enterspeed.Source.SitecoreCms.V9.Services
                 IEnterspeedFieldValueConverter converter = fieldValueConverters.FirstOrDefault(x => x.CanConvert(field));
 
                 var value = converter?.Convert(item, field, siteInfo, fieldValueConverters, configuration);
-                if (value == null)
-                {
-                    continue;
-                }
 
                 output.Add(_fieldService.GetFieldName(field), value);
             }

--- a/src/Enterspeed.Source.SitecoreCms.V9/Services/EnterspeedFieldConverter.cs
+++ b/src/Enterspeed.Source.SitecoreCms.V9/Services/EnterspeedFieldConverter.cs
@@ -25,6 +25,8 @@ namespace Enterspeed.Source.SitecoreCms.V9.Services
         {
             var output = new Dictionary<string, IEnterspeedProperty>();
 
+            item.Fields.ReadAll();
+
             FieldCollection fieldsCollection = item.Fields;
             if (fieldsCollection == null || !fieldsCollection.Any())
             {


### PR DESCRIPTION
Simple fix to include fields that either contains standard values or that does not have any value. 